### PR TITLE
Wave1 Step 1: timing-risk guidance consolidation

### DIFF
--- a/docs/DROP_IN_SKETCHES.md
+++ b/docs/DROP_IN_SKETCHES.md
@@ -114,6 +114,9 @@ Equivalent CLI flags are also supported:
 3. Keep Arduino IDE Serial Monitor closed during playlist runs.
 4. Space key skip always overrides current wait/hold path and advances to next stage.
 5. If `WAIT_FOR_DONE=true` and a duration suffix exists, that duration becomes token timeout for that sketch.
+6. Duration precedence can be misread; verify effective values with:
+   - `./scripts/run_playlist.sh --print-playlist-plan true`
+7. Very large timer values are accepted, but LCD display is fixed to `HH:MM:SS` width.
 
 ## See also
 


### PR DESCRIPTION
Step 1 of visible reconciliation stack. Folds timing-risk guidance into existing docs without adding new doc files.