### PR TITLE
Wave1 Step 3: timer display bounds hardening

### DIFF
--- a/src/playlist/06_lcd_afoqt_timer_003000.ino
+++ b/src/playlist/06_lcd_afoqt_timer_003000.ino
@@ -35,7 +35,10 @@ char serialBuf[kInputMax + 1];
 size_t serialLen = 0;
 
 void formatHhMmSs(unsigned long totalSeconds, char* out, size_t outLen) {
-  const unsigned long hours = totalSeconds / 3600UL;
+  // Keep LCD representation fixed-width HH:MM:SS.
+  // Internal timer state can exceed 99h, but display is capped for stability.
+  const unsigned long hoursRaw = totalSeconds / 3600UL;
+  const unsigned long hours = (hoursRaw > 99UL) ? 99UL : hoursRaw;
   const unsigned long minutes = (totalSeconds % 3600UL) / 60UL;
   const unsigned long seconds = totalSeconds % 60UL;
   snprintf(out, outLen, "%02lu:%02lu:%02lu", hours, minutes, seconds);


### PR DESCRIPTION
Step 3 of visible reconciliation stack. Hardens HH:MM:SS display bounds behavior in timer firmware.